### PR TITLE
Fix to work with Pavian script formatted count tables

### DIFF
--- a/scripts/reads_summary.R
+++ b/scripts/reads_summary.R
@@ -29,7 +29,7 @@ create_summary_table <- function(read_table, dataset_name){
   ta <- subset(read_table, name %in% taxa_list) %>% 
     select_if(str_detect(names(.), "name|cladeReads")) %>% 
     tidyr::pivot_longer(
-      cols = ends_with("cladeReads"),
+      cols = contains("cladeReads"),
       names_to = "sample",
       values_to = "reads"
     )

--- a/scripts/snippets/pavian_aggregate.R
+++ b/scripts/snippets/pavian_aggregate.R
@@ -1,13 +1,14 @@
 # This script reads in kraken reports and agglomerates them into analytic 
 # matrices for both clade and taxon reads via Pavian.
+#
+# NO TAXA ARE FILTERED OUT AT THIS TIME
 # Load packages -----------------------------------------------------------
 
 packages <- c("pavian",
               "dplyr",
               "purrr",
               "stringr",
-              "tidyr",
-              "glue")
+              "tidyr")
 lapply(packages, library, character.only = TRUE)
 
 
@@ -42,13 +43,13 @@ widen_results_function <- function(krakenReportPaths, outpath) {
     select(-percentage) %>% 
     pivot_wider(names_from = Sample, 
                 values_from = c(cladeReads, taxonReads)) %>% 
-    relocate(name)
-  
+    relocate(name) %>% 
+    relocate(taxLineage, .after = last_col())
   write.csv(merged_wide, outpath, row.names = FALSE)
 }
 
-krakenReportPaths <- Sys.glob("../data/ctx_2020/kraken_reports/*d0*_report.txt") %>% 
-  c(Sys.glob("../data/ctx_2020/kraken_reports/*dC*_report.txt"))
+krakenReportPaths <- Sys.glob("../data/ctx_2020/kraken_reports/*_report.txt")
+  # c(Sys.glob("../data/ctx_2020/kraken_reports/*dC*_report.txt"))
 
 outpath <- "../data/ctx_2020/CTX_dC_all_taxa.csv" 
 widen_results_function(krakenReportPaths, outpath)

--- a/scripts/snippets/taxa_cutoff_explore.R
+++ b/scripts/snippets/taxa_cutoff_explore.R
@@ -1,4 +1,4 @@
-# This code snippet may be used with the 'scaled clade' table produced in main.R
+# This code snippet may be used with the 'raw clade' table produced in main.R
 # to produce a list of taxa above and below a certain abundance threshold.
 
 # The min_abundance is the percent at which a taxon's relative abundance 
@@ -11,7 +11,7 @@ min_abundance <- 1
 min_samples_above_cutoff <- 2
 
 
-pc_sc <- select(sc, matches('.*(Reads|name|Rank).*'))
+pc_sc <- select(tables[["raw_clade"]], matches('.*(Reads|name|Rank).*'))
 bac_sc <- pc_sc %>% filter(name == 'Bacteria')
 
 # Get proportions using Bacteria count as total
@@ -28,9 +28,9 @@ taxa_above_cutoff <- pc_sc %>%
   filter(num_samples_above_thresh >= min_samples_above_cutoff)
 
 # Get table of taxa below cutoff
-taxa_below_cutoff <- pc_sc %>% 
-  mutate(num_samples_above_thresh = rowSums(pc_sc[c(-1,-2)] >= min_abundance)) %>% 
-  filter(num_samples_above_thresh < min_samples_above_cutoff)
+# taxa_below_cutoff <- pc_sc %>% 
+#   mutate(num_samples_above_thresh = rowSums(pc_sc[c(-1,-2)] >= min_abundance)) %>% 
+#   filter(num_samples_above_thresh < min_samples_above_cutoff)
 
-write_csv(taxa_above_cutoff[c(1,2)], file=str_glue("taxa_above_cutoff_{min_abundance}p.csv"))
-write_csv(taxa_below_cutoff[c(1,2)], file=str_glue("taxa_below_cutoff_{min_abundance}p.csv"))
+write_csv(taxa_above_cutoff[c(1,2)], file=str_glue("{main_outdir}/taxa_above_cutoff_{min_abundance}p.csv"))
+# write_csv(taxa_below_cutoff[c(1,2)], file=str_glue("{main_outdir}/taxa_below_cutoff_{min_abundance}p.csv"))


### PR DESCRIPTION
We now use an R script to aggregate kraken reports via Pavian (scripts/snippets/pavian_aggregate.R). The format of the output table is slightly different than that produced by the Pavian interactive tool. The script is preferred, so updates were needed to make code compatible with the new format.
Another change is, in the da-ancombc.R and exploratory_functions.R scripts, I've replaced the old method of creating metadata columns for treatment and replicate. The prior method assumed columns of the input table were ordered in a specific way, and required the user to provide a list of treatment and replicate names. The new way uses regular expressions (regex) to extract this information from the sample names. It still requires some user input to map sample name treatment encodings (e.g. d0,d1) to actual treatment names (e.g. control, oxytetracycline).
The regex's used here should ideally fit all known dataset naming patterns, but may be a source of error if conventions change for further datasets